### PR TITLE
TComp Template Application and bug fix

### DIFF
--- a/HelixTroubleshooting/Change Log.txt
+++ b/HelixTroubleshooting/Change Log.txt
@@ -1,3 +1,9 @@
+3.4.0
+	--Added further automation to t-comp template generation.
+		"Apply TComp Template" allows the user to enter a serial number and number of months, then have the template applied automatically, as well as logged for tracking purposes.
+	--Fixed a bug with illuminated sphere summary that caused crashing due to tiff tag 37374.
+	--Improved the performance of illuminated sphere sumamry by promptly disposing of images when they're no longer needed.
+
 3.3.0
 	--Added function to create "R" part number config files for Evo and Solo sensors, based on configs that are present for non-R part numbers.
 	--Applied alsSensitivity config variable, where the function previously explicitly defined "3".

--- a/HelixTroubleshooting/Functions/Sphere Summary.cs
+++ b/HelixTroubleshooting/Functions/Sphere Summary.cs
@@ -25,7 +25,7 @@ namespace HelixTroubleshootingWPF.Functions
 
             //MagickReadSettings to ignore null tag 37373 in tif images generated during rectification.
             var settings = new MagickReadSettings();
-            settings.SetDefine("tiff:ignore-tags", "37373");
+            settings.SetDefine("tiff:ignore-tags", "37373,37374");
 
             //Create summary folder
             string summaryFolder = $@"{System.IO.Path.GetDirectoryName(images[0])}\Summary";
@@ -56,10 +56,13 @@ namespace HelixTroubleshootingWPF.Functions
                             //if (image2.Contains(zValue))
                             if(System.IO.Path.GetFileName(image2).Split("Y")[0] == zValue)
                             {
-                                summaryImage.Composite(new MagickImage(image2, settings), CompositeOperator.Lighten);
+                                MagickImage magickImage2 = new MagickImage(image2, settings);
+                                summaryImage.Composite(magickImage2, CompositeOperator.Lighten);
+                                magickImage2.Dispose();
                             }
                         }
                         summaryImage.Write($@"{summaryFolder}\{zValue}.tif");
+                        summaryImage.Dispose();
                         break;
                     }
                 }

--- a/HelixTroubleshooting/Functions/TTools.cs
+++ b/HelixTroubleshooting/Functions/TTools.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Windows;
 using HelixTroubleshootingWPF.Objects;
 //namespace Helix_Troubleshooting_CS
@@ -14,7 +15,7 @@ namespace HelixTroubleshootingWPF.Functions
         //Array of strings to be added to function list
         public static readonly string[] functionList = new string[] {"ALS Point Removal","Fix Algorithm Errors","Illuminated Sphere Summary",
             "Solo Laser Line Analysis","Staring Dot Removal","Temperature Adjust", "DACMEMS Data Gather", "UFF Data Gather", "LPF Data Gather",
-            "Pitch Data Gather","Evo Data Gather", "Sensor Test", "Generate TComp Template", "Evo Performance Reports", "Create R Configs", "Test"};// "Evo KNN", "Evo KNN Regression", "KNN Validation", "Test ML.net"};
+            "Pitch Data Gather","Evo Data Gather", "Sensor Test", "Generate Generic TComp", "Apply TComp Template", "Evo Performance Reports", "Create R Configs", "Test"};// "Evo KNN", "Evo KNN Regression", "KNN Validation", "Test ML.net"};
 
         public static TToolsConfig Config = new();
         //Private Helper Functions----------------------------------------------------------------------------------------
@@ -42,9 +43,9 @@ namespace HelixTroubleshootingWPF.Functions
         private static string GetGroupFolder(string directory, string sn)
         {
             string folder = "";
-            if(sn.Length == 8)
+            if(Regex.IsMatch(sn, @"\d{6}$"))
             {
-                sn = sn.Remove(5) + "XXX";
+                sn = "SN" + Regex.Match(sn, @"\d{6}$").Value.Substring(0,3) + "XXX";
                 folder = Directory.Exists($@"{directory}\{sn}") ? $@"{directory}\{sn}" : "";
             }
             return folder;

--- a/HelixTroubleshooting/HelixTroubleshooting.csproj
+++ b/HelixTroubleshooting/HelixTroubleshooting.csproj
@@ -5,15 +5,15 @@
     <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon>bar.ico</ApplicationIcon>
-    <Version>3.3.1</Version>
+    <Version>3.4.0</Version>
     <Company>Perceptron, Inc.</Company>
     <Authors>Gregg Robinson</Authors>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <IncludeAllContentForSelfExtract>true</IncludeAllContentForSelfExtract>
-    <FileVersion>3.3.0.0</FileVersion>
-    <AssemblyVersion>3.3.1.0</AssemblyVersion>
+    <FileVersion>3.4.0.0</FileVersion>
+    <AssemblyVersion>3.4.0.0</AssemblyVersion>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
 

--- a/HelixTroubleshooting/MainWindow.xaml.cs
+++ b/HelixTroubleshooting/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.Timers;
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace HelixTroubleshootingWPF
 {
@@ -13,7 +14,7 @@ namespace HelixTroubleshootingWPF
     /// </summary>
     public partial class MainWindow : Window
     {
-        public readonly string Version = "3.3.1";
+        public readonly string Version = "3.4.0";
        
         public MainWindow()
         {
@@ -165,11 +166,22 @@ namespace HelixTroubleshootingWPF
                 DataGatherSettings();
                 DetailsTextBox1.Visibility = Visibility.Visible;
             }
-            else if (item == "Generate TComp Template")
+            else if (item == "Generate Generic TComp")
             {
                 DetailsBox.Text = "Generate a Tcomp template for a given Evo sensor model." +
                     " Enter the first 7 digits of the part number in the format \"XXX-XXXX\"" +
-                    " and enter a number of months for the range of t-comp templates to include.";
+                    " and enter a number of months for the range of t-comp files to include.";
+                DetailsTextBox1.Visibility = Visibility.Visible;
+                DetailsTextBox2.Visibility = Visibility.Visible;
+                DetailsButton1.Visibility = Visibility.Visible;
+                DetailsButton2.Visibility = Visibility.Hidden;
+            }
+            else if (item == "Apply TComp Template")
+            {
+                DetailsBox.Text = "Apply a Tcomp template for a specified sensor. " +
+                    "The generated template will overwrite t-comp data that already exists for the sensor." +
+                    " Enter the serial number of ther sensor" +
+                    " and enter a number of months for the range of t-comp files to include.";
                 DetailsTextBox1.Visibility = Visibility.Visible;
                 DetailsTextBox2.Visibility = Visibility.Visible;
                 DetailsButton1.Visibility = Visibility.Visible;
@@ -289,11 +301,22 @@ namespace HelixTroubleshootingWPF
             {
                 TToolsFunctions.RunCombos();
             }
-            else if(function == "Generate TComp Template")
+            else if(function == "Generate Generic TComp")
             {
                 try
                 {
                     TToolsFunctions.Template(DetailsTextBox1.Text, int.Parse(DetailsTextBox2.Text));
+                }
+                catch(Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Template Generation Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                }
+            }
+            else if(function == "Apply TComp Template")
+            {
+                try
+                {
+                    TToolsFunctions.ApplyTemplate(Regex.Match(DetailsTextBox1.Text, @"\d{6}$").Value, int.Parse(DetailsTextBox2.Text));
                 }
                 catch(Exception ex)
                 {
@@ -356,7 +379,7 @@ namespace HelixTroubleshootingWPF
         {
             foreach (ListViewItem item in FunctionList.Items)
             {
-                if (item.Content.ToString().Contains("Data Gather"))
+                if (item.Content.ToString().Contains("Data Gather") || item.Content.ToString().Contains("Generic"))
                 {
                     if (item.Visibility == Visibility.Visible)
                     { item.Visibility = Visibility.Collapsed; }

--- a/HelixTroubleshooting/Objects/Image.cs
+++ b/HelixTroubleshooting/Objects/Image.cs
@@ -47,7 +47,7 @@ namespace HelixTroubleshootingWPF.Objects
         //Constructors
         public HelixImage()
         {
-            settings.SetDefine("tiff:ignore-tags", "37373");
+            settings.SetDefine("tiff:ignore-tags", "37373,37374");
         }
         public HelixImage(string path)
         {
@@ -61,7 +61,7 @@ namespace HelixTroubleshootingWPF.Objects
         }
         public HelixImage(string path, MagickImage magick)
         {
-            settings.SetDefine("tiff:ignore-tags", "37373");
+            settings.SetDefine("tiff:ignore-tags", "37373,37374");
             this.path = path;
             Name = System.IO.Path.GetFileName(path);
             this.Magick = magick;


### PR DESCRIPTION
--Added further automation to t-comp template generation. "Apply TComp Template" allows the user to enter a serial number and number of months, then have the template applied automatically, as well as logged for tracking purposes.
--Fixed a bug with illuminated sphere summary that caused crashing due to tiff tag 37374.
--Improved the performance of illuminated sphere sumamry by promptly disposing of images when they're no longer needed.
